### PR TITLE
use a timer rather than recursion in continuous receive mode

### DIFF
--- a/GCDAsyncUdpSocket.m
+++ b/GCDAsyncUdpSocket.m
@@ -4479,12 +4479,7 @@ enum GCDAsyncUdpSocketConfig
 	}
 	else
 	{
-		if (flags & kReceiveContinuous)
-		{
-			// Continuous receive mode
-			[self doReceive];
-		}
-		else
+		if (flags & kReceiveOnce)
 		{
 			// One-at-a-time receive mode
 			if (notifiedDelegate)
@@ -4502,6 +4497,16 @@ enum GCDAsyncUdpSocketConfig
 				// Waiting on asynchronous receive filter...
 			}
 		}
+        else
+        {
+            // This used to be a recursive call, but we overran the stack, so use a timer
+            // instead so that in the case of high traffic, at least we don't crash.
+            [NSTimer scheduledTimerWithTimeInterval:0
+                                             target:self
+                                           selector:@selector(doReceive)
+                                           userInfo:nil
+                                            repeats:NO];
+        }
 	}
 }
 


### PR DESCRIPTION
we were getting memory access errors, I believe caused by stack overflows

before: crashed at sending &{/cue/title/scaleX  [489033 messages and 2m39.781532876s elapsed]}
after: still going at sending &{/cue/title/scaleX  [993412 messages and 5m21.802203333s elapsed]}

BUT the queue is unmanageably big, and i think that it would probably be worth figuring out a strategy for rate-limiting incoming OSC messages or just notifying users when they've sent in too many at once (we can determine how many bytes still need to be read from the UDP socket, which can grow to megs, I believe)