### PR TITLE
Change wildcard code to build predicates that match more than just va…

### DIFF
--- a/F53OSCServer.m
+++ b/F53OSCServer.m
@@ -85,9 +85,8 @@ NS_ASSUME_NONNULL_BEGIN
     if ( [[pattern componentsSeparatedByString:@"{"] count] != [[pattern componentsSeparatedByString:@"}"] count] )
         return nil;
 
-    NSString *validOscChars = [F53OSCServer stringWithSpecialRegexCharactersEscaped:[F53OSCServer validCharsForOSCMethod]];
-    NSString *wildCard = [NSString stringWithFormat:@"[%@]*", validOscChars];
-    NSString *oneChar = [NSString stringWithFormat:@"[%@]{1}?", validOscChars];
+    NSString *wildCard = @".*";
+    NSString *oneChar = @".{1}?";
 
     // Escape characters that are special in regex (ICU v3) but not special in OSC.
     pattern = [F53OSCServer stringWithSpecialRegexCharactersEscaped:pattern];


### PR DESCRIPTION
…lid OSC characters, since the predicate applies to strings that exist outside the scope of OSC.

This is intended to fix an issue in QLab where messages like `/cue/*/start` would not match cues that include spaces, forward slashes, etc. in their cue numbers.