### PR TITLE
Fix `outLength` returned by `dataWithOSCBlobBytes:maxLength:length:`

### DIFF
--- a/F53OSCParser.m
+++ b/F53OSCParser.m
@@ -211,8 +211,8 @@ NS_ASSUME_NONNULL_BEGIN
                         if ( dataArg != nil )
                         {
                             [args addObject:dataArg];
-                            buffer += dataLength + 4;
-                            lengthOfRemainingBuffer -= (dataLength + 4);
+                            buffer += dataLength;
+                            lengthOfRemainingBuffer -= dataLength;
                             
                             if ( [[NSUserDefaults standardUserDefaults] boolForKey:@"debugIncomingOSC"] )
                                 NSLog( @"    blob: %@", dataArg );

--- a/F53OSCParser.m
+++ b/F53OSCParser.m
@@ -67,9 +67,9 @@ NS_ASSUME_NONNULL_BEGIN
     const char *buffer = [data bytes];
     
     NSUInteger lengthOfRemainingBuffer = length;
-    NSUInteger dataLength = 0;
-    NSString *bundlePrefix = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer length:&dataLength];
-    if ( bundlePrefix == nil || dataLength == 0 || dataLength > length )
+    NSUInteger bytesRead = 0;
+    NSString *bundlePrefix = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer bytesRead:&bytesRead];
+    if ( bundlePrefix == nil || bytesRead == 0 || bytesRead > length )
     {
         NSLog( @"Error: Unable to parse OSC bundle prefix." );
         return;
@@ -77,8 +77,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     if ( [bundlePrefix isEqualToString:@"#bundle"] )
     {
-        buffer += dataLength;
-        lengthOfRemainingBuffer -= dataLength;
+        buffer += bytesRead;
+        lengthOfRemainingBuffer -= bytesRead;
         
         if ( lengthOfRemainingBuffer > 8 )
         {
@@ -142,29 +142,29 @@ NS_ASSUME_NONNULL_BEGIN
     const char *buffer = [data bytes];
     
     NSUInteger lengthOfRemainingBuffer = length;
-    NSUInteger dataLength = 0;
-    NSString *addressPattern = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer length:&dataLength];
-    if ( addressPattern == nil || dataLength == 0 || dataLength > length )
+    NSUInteger bytesRead = 0;
+    NSString *addressPattern = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer bytesRead:&bytesRead];
+    if ( addressPattern == nil || bytesRead == 0 || bytesRead > length )
     {
         NSLog( @"Error: Unable to parse OSC method address." );
         return nil;
     }
     
-    buffer += dataLength;
-    lengthOfRemainingBuffer -= dataLength;
+    buffer += bytesRead;
+    lengthOfRemainingBuffer -= bytesRead;
     
     NSMutableArray *args = [NSMutableArray array];
     BOOL hasArguments = (lengthOfRemainingBuffer > 0);
     if ( hasArguments && buffer[0] == ',' )
     {
-        NSString *typeTag = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer length:&dataLength];
+        NSString *typeTag = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer bytesRead:&bytesRead];
         if ( typeTag == nil )
         {
             NSLog( @"Error: Unable to parse type tag for OSC method %@", addressPattern );
             return nil;
         }
-        buffer += dataLength;
-        lengthOfRemainingBuffer -= dataLength;
+        buffer += bytesRead;
+        lengthOfRemainingBuffer -= bytesRead;
         
         if ( [[NSUserDefaults standardUserDefaults] boolForKey:@"debugIncomingOSC"] )
         {
@@ -188,13 +188,13 @@ NS_ASSUME_NONNULL_BEGIN
                 switch ( type )
                 {
                     case 's':
-                        dataLength = 0; // reset
-                        stringArg = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer length:&dataLength];
+                        bytesRead = 0; // reset
+                        stringArg = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer bytesRead:&bytesRead];
                         if ( stringArg != nil )
                         {
                             [args addObject:stringArg];
-                            buffer += dataLength;
-                            lengthOfRemainingBuffer -= dataLength;
+                            buffer += bytesRead;
+                            lengthOfRemainingBuffer -= bytesRead;
                             
                             if ( [[NSUserDefaults standardUserDefaults] boolForKey:@"debugIncomingOSC"] )
                                 NSLog( @"    string: \"%@\"", stringArg );
@@ -206,13 +206,13 @@ NS_ASSUME_NONNULL_BEGIN
                         }
                         break;
                     case 'b':
-                        dataLength = 0; // reset
-                        dataArg = [NSData dataWithOSCBlobBytes:buffer maxLength:lengthOfRemainingBuffer length:&dataLength];
+                        bytesRead = 0; // reset
+                        dataArg = [NSData dataWithOSCBlobBytes:buffer maxLength:lengthOfRemainingBuffer bytesRead:&bytesRead];
                         if ( dataArg != nil )
                         {
                             [args addObject:dataArg];
-                            buffer += dataLength;
-                            lengthOfRemainingBuffer -= dataLength;
+                            buffer += bytesRead;
+                            lengthOfRemainingBuffer -= bytesRead;
                             
                             if ( [[NSUserDefaults standardUserDefaults] boolForKey:@"debugIncomingOSC"] )
                                 NSLog( @"    blob: %@", dataArg );

--- a/F53OSCParser.m
+++ b/F53OSCParser.m
@@ -3,7 +3,7 @@
 //
 //  Created by Christopher Ashworth on 1/30/13.
 //
-//  Copyright (c) 2013-2018 Figure 53 LLC, http://figure53.com
+//  Copyright (c) 2013-2020 Figure 53 LLC, http://figure53.com
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -188,6 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
                 switch ( type )
                 {
                     case 's':
+                        dataLength = 0; // reset
                         stringArg = [NSString stringWithOSCStringBytes:buffer maxLength:lengthOfRemainingBuffer length:&dataLength];
                         if ( stringArg != nil )
                         {
@@ -205,6 +206,7 @@ NS_ASSUME_NONNULL_BEGIN
                         }
                         break;
                     case 'b':
+                        dataLength = 0; // reset
                         dataArg = [NSData dataWithOSCBlobBytes:buffer maxLength:lengthOfRemainingBuffer length:&dataLength];
                         if ( dataArg != nil )
                         {

--- a/NSData+F53OSCBlob.h
+++ b/NSData+F53OSCBlob.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSData (F53OSCBlobAdditions)
 
 - (NSData *) oscBlobData;
-+ (nullable NSData *) dataWithOSCBlobBytes:(const char *)buf maxLength:(NSUInteger)maxLength length:(NSUInteger *)outLength;
++ (nullable NSData *) dataWithOSCBlobBytes:(const char *)buf maxLength:(NSUInteger)maxLength bytesRead:(out NSUInteger *)outBytesRead;
 
 @end
 

--- a/NSData+F53OSCBlob.m
+++ b/NSData+F53OSCBlob.m
@@ -3,7 +3,7 @@
 //
 //  Created by Sean Dougall on 1/17/11.
 //
-//  Copyright (c) 2011-2018 Figure 53 LLC, http://figure53.com
+//  Copyright (c) 2011-2020 Figure 53 LLC, http://figure53.com
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSData *) dataWithOSCBlobBytes:(const char *)buf maxLength:(NSUInteger)maxLength length:(NSUInteger *)outLength
 {
     if ( buf == NULL || maxLength == 0 )
+    {
+        if ( outLength != NULL )
+            *outLength = 0;
         return nil;
+    }
     
     UInt32 dataSize = 0;
     
@@ -62,9 +66,15 @@ NS_ASSUME_NONNULL_BEGIN
     dataSize = OSSwapBigToHostInt32( dataSize );
     
     if ( dataSize + 4 > maxLength )
+    {
+        if ( outLength != NULL )
+            *outLength = 0;
         return nil;
+    }
     
-    *outLength = dataSize;
+    if ( outLength != NULL )
+        *outLength = dataSize;
+    
     buf += 4;
     return [NSData dataWithBytes:buf length:dataSize];
 }

--- a/NSData+F53OSCBlob.m
+++ b/NSData+F53OSCBlob.m
@@ -55,12 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
 ///  An OSC blob is an int32 size count followed by a sequence of 8-bit bytes,
 ///  followed by 0-3 additional null characters to make the total number of bits a multiple of 32.
 ///
-+ (nullable NSData *) dataWithOSCBlobBytes:(const char *)buf maxLength:(NSUInteger)maxLength length:(NSUInteger *)outLength
++ (nullable NSData *) dataWithOSCBlobBytes:(const char *)buf maxLength:(NSUInteger)maxLength bytesRead:(out NSUInteger *)outBytesRead
 {
     if ( buf == NULL || maxLength == 0 )
     {
-        if ( outLength != NULL )
-            *outLength = 0;
+        if ( outBytesRead != NULL )
+            *outBytesRead = 0;
         return nil;
     }
     
@@ -71,21 +71,21 @@ NS_ASSUME_NONNULL_BEGIN
     
     if ( dataSize + 4 > maxLength )
     {
-        if ( outLength != NULL )
-            *outLength = 0;
+        if ( outBytesRead != NULL )
+            *outBytesRead = 0;
         return nil;
     }
     
-    if ( outLength != NULL )
-        *outLength = dataSize;
+    if ( outBytesRead != NULL )
+        *outBytesRead = dataSize;
     
     buf += 4;
     NSData *result = [NSData dataWithBytes:buf length:dataSize];
     
-    if ( outLength != NULL )
+    if ( outBytesRead != NULL )
     {
-        NSUInteger length = result.length + 4; // include length of size count byte
-        *outLength = ( 4 * ceil( length / 4.0 ) ); // round up to a multiple of 32 bits
+        NSUInteger bytesRead = result.length + 4; // include length of size count byte
+        *outBytesRead = ( 4 * ceil( bytesRead / 4.0 ) ); // round up to a multiple of 32 bits
     }
     
     return result;

--- a/NSData+F53OSCBlob.m
+++ b/NSData+F53OSCBlob.m
@@ -51,6 +51,10 @@ NS_ASSUME_NONNULL_BEGIN
     return [newData copy];
 }
 
+///
+///  An OSC blob is an int32 size count followed by a sequence of 8-bit bytes,
+///  followed by 0-3 additional null characters to make the total number of bits a multiple of 32.
+///
 + (nullable NSData *) dataWithOSCBlobBytes:(const char *)buf maxLength:(NSUInteger)maxLength length:(NSUInteger *)outLength
 {
     if ( buf == NULL || maxLength == 0 )
@@ -76,7 +80,15 @@ NS_ASSUME_NONNULL_BEGIN
         *outLength = dataSize;
     
     buf += 4;
-    return [NSData dataWithBytes:buf length:dataSize];
+    NSData *result = [NSData dataWithBytes:buf length:dataSize];
+    
+    if ( outLength != NULL )
+    {
+        NSUInteger length = result.length + 4; // include length of size count byte
+        *outLength = ( 4 * ceil( length / 4.0 ) ); // round up to a multiple of 32 bits
+    }
+    
+    return result;
 }
 
 @end

--- a/NSString+F53OSCString.h
+++ b/NSString+F53OSCString.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSString (F53OSCStringAdditions)
 
 - (NSData *) oscStringData;
-+ (nullable NSString *) stringWithOSCStringBytes:(const char *)buf maxLength:(NSUInteger)maxLength length:(NSUInteger *)outLength;
++ (nullable NSString *) stringWithOSCStringBytes:(const char *)buf maxLength:(NSUInteger)maxLength bytesRead:(out NSUInteger *)outBytesRead;
 
 @end
 

--- a/NSString+F53OSCString.m
+++ b/NSString+F53OSCString.m
@@ -3,7 +3,7 @@
 //
 //  Created by Sean Dougall on 1/17/11.
 //
-//  Copyright (c) 2011-2018 Figure 53 LLC, http://figure53.com
+//  Copyright (c) 2011-2020 Figure 53 LLC, http://figure53.com
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -64,21 +64,30 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSString *) stringWithOSCStringBytes:(const char *)buf maxLength:(NSUInteger)maxLength length:(NSUInteger *)outLength
 {
     if ( buf == NULL || maxLength == 0 )
+    {
+        if ( outLength != NULL )
+            *outLength = 0;
         return nil;
+    }
     
     for ( NSUInteger index = 0; index < maxLength; index++ )
     {
         if ( buf[index] == 0 )
             goto valid; // found a NULL character within the buffer
     }
-    return nil; // Buffer wasn't null terminated, so it's not a valid OSC string.
+    
+    // Buffer wasn't null terminated, so it's not a valid OSC string.
+    if ( outLength != NULL )
+        *outLength = 0;
+    return nil;
     
 valid:;
     
-    NSString *result = nil;
+    NSString *result = [NSString stringWithUTF8String:buf];
     
-    result = [NSString stringWithUTF8String:buf];
-    *outLength = 4 * ceil( ([result length] + 1) / 4.0 );
+    if ( outLength != NULL )
+        *outLength = 4 * ceil( ([result length] + 1) / 4.0 );
+    
     return result;
 }
 

--- a/NSString+F53OSCString.m
+++ b/NSString+F53OSCString.m
@@ -61,12 +61,12 @@ NS_ASSUME_NONNULL_BEGIN
 ///  An OSC string is a sequence of non-null ASCII characters followed by a null,
 ///  followed by 0-3 additional null characters to make the total number of bits a multiple of 32.
 ///
-+ (nullable NSString *) stringWithOSCStringBytes:(const char *)buf maxLength:(NSUInteger)maxLength length:(NSUInteger *)outLength
++ (nullable NSString *) stringWithOSCStringBytes:(const char *)buf maxLength:(NSUInteger)maxLength bytesRead:(out NSUInteger *)outBytesRead
 {
     if ( buf == NULL || maxLength == 0 )
     {
-        if ( outLength != NULL )
-            *outLength = 0;
+        if ( outBytesRead != NULL )
+            *outBytesRead = 0;
         return nil;
     }
     
@@ -77,18 +77,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     // Buffer wasn't null terminated, so it's not a valid OSC string.
-    if ( outLength != NULL )
-        *outLength = 0;
+    if ( outBytesRead != NULL )
+        *outBytesRead = 0;
     return nil;
     
 valid:;
     
     NSString *result = [NSString stringWithUTF8String:buf];
     
-    if ( outLength != NULL )
+    if ( outBytesRead != NULL )
     {
-        NSUInteger length = result.length + 1; // include length of null terminator character
-        *outLength = 4 * ceil( length / 4.0 ); // round up to a multiple of 32 bits
+        NSUInteger bytesRead = result.length + 1; // include length of null terminator character
+        *outBytesRead = 4 * ceil( bytesRead / 4.0 ); // round up to a multiple of 32 bits
     }
     
     return result;

--- a/NSString+F53OSCString.m
+++ b/NSString+F53OSCString.m
@@ -86,7 +86,10 @@ valid:;
     NSString *result = [NSString stringWithUTF8String:buf];
     
     if ( outLength != NULL )
-        *outLength = 4 * ceil( ([result length] + 1) / 4.0 );
+    {
+        NSUInteger length = result.length + 1; // include length of null terminator character
+        *outLength = 4 * ceil( length / 4.0 ); // round up to a multiple of 32 bits
+    }
     
     return result;
 }


### PR DESCRIPTION
Parsing an OSC message can fail when message data follows OSC Blob data.

When reading a buffer of OSC message data, Blob data is converted using NSData category method `-[NSData dataWithOSCBlobBytes:maxLength:length:]`. F53OSCParser then advances the cursor according to the `outLength` returned by that method. Currently, that length is not guaranteed to be a multiple of 4 bytes. This can cause subsequent OSC types in the same OSC message to be parsed incorrectly because the buffer is no longer aligned at a 32-bit boundary.

This PR updates the NSData+F53OSCBlob category method `-[NSData dataWithOSCBlobBytes:maxLength:length:]` to follow the same pattern the related NSString+F53OSCString category method uses. In addition, this PR also guards against some potential NULL dereferences in the handling of `outLength`.